### PR TITLE
fix: improve CLI UX and fix Brighten saturation bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,8 @@ checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -278,12 +280,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itoa"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
@@ -308,6 +304,25 @@ name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+
+[[package]]
+name = "memchr"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "noyalib"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e493c05128df7a83b9676b709d590e0ebc285c7ed3152bc679668e8c1e506af5"
+dependencies = [
+ "indexmap",
+ "memchr",
+ "rustc-hash",
+ "serde",
+ "smallvec",
+]
 
 [[package]]
 name = "number_prefix"
@@ -357,7 +372,7 @@ dependencies = [
  "rand",
  "rayon",
  "serde",
- "serde_yaml",
+ "serde_yml",
  "walkdir",
 ]
 
@@ -450,16 +465,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -501,16 +516,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yml"
+version = "0.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "909764a65f86829ccdb5eea9ab355843aa02c019a7bfd47465092953565caa05"
 dependencies = [
- "indexmap",
- "itoa",
- "ryu",
+ "noyalib",
  "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -524,6 +536,12 @@ name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"
@@ -573,12 +591,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ webp-glitch = { path = "crates/webp-glitch", version = "0.1.0" }
 rand = "0.9.2"
 log = "0.4.22"
 serde = { version = "1.0", features = ["derive"] }
-serde_yaml = "0.9"
 walkdir = "2.5"
 indicatif = "0.17"
 rayon = "1.10"
+serde_yml = "0.0.13"

--- a/README.md
+++ b/README.md
@@ -59,6 +59,49 @@ filters:
     r_offset: 3
     b_offset: -3
   - type: Invert
+  - type: Invert
+  - type: PixelSort
+    magnitude: 0.1
+    criterion: hue
+  - type: HorizontalShift
+    magnitude: 0.05
+  - type: Bitwise
+    magnitude: 0.02
+    op: xor
+    value: 255
+```
+
+Run it with:
+```zsh
+% png-glitch input.png --config my_glitch.yaml
+```
+
+## Documentation
+
+- **[Developer & Architecture Guide](DEVELOPER_GUIDE.md)**: Deep dive into the internal design and core concepts.
+- **[Spec: Filter System](crates/png-glitch/specs/FILTER_SYSTEM.md)**: Technical details on PNG filters.
+- **[Spec: Pixel Formats](crates/png-glitch/specs/PIXEL_FORMATS.md)**: How we handle different bit depths and color types.
+
+## Example
+
+The original image:
+![The original PNG file is a photo of a media art placed in a slightly darker space.](crates/png-glitch/etc/sample00.png)
+
+And the glitched one:
+![](crates/png-glitch/etc/sample00-glitched.png)
+
+# In this repository
+This repository consists of the following things:
+
+- png-glitch-cli, a binary crate for a command line interface (CLI) to glitch PNG files.
+- [png-glitch crate](crates/png-glitch), a library to glitch PNG images.
+- [glitch-context crate](crates/glitch-context), a high-level API to orchestrate glitch filters.
+
+# Licence
+
+MIT License. Please refer to [LICENCE](LICENSE) file for details.
+FilterType
+    magnitude: 0.05
 ```
 
 Run it with:

--- a/README.md
+++ b/README.md
@@ -14,24 +14,64 @@ To install `png-glitch` from source, run the following command:
 
 `png-glitch` glitches given PNG file (or directory) and emits the result. By default, it saves to `glitched.png`.
 
-### Command Line Options
+```zsh
+% png-glitch [OPTIONS] <PNG_FILE>
+% png-glitch input.png -o result.png --invert
+% png-glitch input.png --output result.png --block-scramble 0.1
+```
 
-| Category | Option | Description |
-| :--- | :--- | :--- |
-| **Color** | `--invert` | Inverts all color values. |
-| | `--color-space-glitch <MAG>` | Artistic control over HSL (Hue, Saturation, Lightness). |
-| | `--chromatic-aberration <MAG>` | Classic retro "color fringe" effect. |
-| | `--brighten <N>` | Adjusts brightness (0-65535). |
-| | `--shift-channels <R,G,B>` | Shifts color channels independently. |
-| **Structure** | `--block-scramble <MAG>` | Shuffles grid-based blocks (optimized). |
-| | `--transpose <MAG>` | Randomly swaps blocks of scanlines. |
-| | `--horizontal-shift <MAG>` | Shifts scanlines horizontally. |
-| **Noise** | `--replace <MAG>` | Replaces pixels with noise (0.0 - 1.0). |
-| | `--set-zero <MAG>` | Sets random pixels to zero (0.0 - 1.0). |
-| **PNG Logic** | `--remove-filter` | Strips filters for predictable results. |
-| | `--sub`, `--up`, `--paeth` | Forces specific PNG filter types for streaking. |
-| **Utility** | `--batch-output <DIR>` | Processes a directory in parallel. |
-| | `--seed <N>` | Set a seed for reproducible glitch patterns. |
+### Glitch Filters
+
+Multiple filters can be combined and are applied in the order they are specified.
+
+| Option | Description |
+| :--- | :--- |
+| `--invert` | Inverts all color values. |
+| `--color-space-glitch <MAG>` | Artistic control over HSL (Hue, Saturation, Lightness). |
+| `--chromatic-aberration <MAG>` | Classic retro "color fringe" effect. |
+| `--brighten <N>` | Saturating brightness increase (0–65535). Caps at the maximum value for the image's bit depth. |
+| `--shift-channels <R,G,B>` | Shifts color channels independently (wrapping). |
+| `--block-scramble <MAG>` | Shuffles grid-based blocks. |
+| `--transpose <MAG>` | Randomly swaps blocks of scanlines. |
+| `--horizontal-shift <MAG>` | Shifts scanlines horizontally. |
+| `--replace <MAG>` | Replaces pixels with noise (0.0–1.0). |
+| `--set-zero <MAG>` | Sets random pixels to zero (0.0–1.0). |
+| `--random-copy <N>` | Copies random scanlines N times. |
+| `--substitute <INDEX:VALUE>` | Substitutes a single byte by index. |
+| `--pixel-sort <MAG>` | Sorts pixels by brightness or hue within scanlines. |
+| `--bitwise <MAG>` | Applies a bitwise operation (AND/OR/XOR) to pixel data. |
+| `--channel-swap <MAG>` | Swaps two color channels (RG, GB, or BR). |
+| `--color-distortion <MAG>` | Adds per-scanline color noise. |
+| `--change-filter-type <MAG>` | Randomly changes PNG filter types across scanlines. |
+
+### Pre-processing (applied before glitch filters)
+
+`--pre-process` re-encodes the PNG with a specific filter type before glitching. This changes the underlying byte patterns that glitch filters operate on, producing different visual results.
+
+```zsh
+% png-glitch input.png --pre-process sub-filter --replace 0.05
+```
+
+Accepted values: `remove-filter`, `sub-filter`, `up-filter`, `average-filter`, `paeth-filter`
+
+### Filter Type Override (force all scan lines to a fixed filter type)
+
+These flags forcibly set all scanlines to a single PNG filter type. Unlike `--pre-process`, they are applied as a glitch step in the pipeline and are useful in batch processing workflows.
+
+| Option | Filter type applied to all scanlines |
+| :--- | :--- |
+| `--remove-filter` | None |
+| `--sub` | Sub |
+| `--up` | Up |
+| `--average` | Average |
+| `--paeth` | Paeth |
+
+### Output
+
+| Option | Description |
+| :--- | :--- |
+| `-o`, `--output <FILE>` | Output file path (default: `glitched.png`). |
+| `--seed <N>` | Random seed for reproducible results. |
 
 ## Batch Processing
 

--- a/crates/glitch-context/src/lib.rs
+++ b/crates/glitch-context/src/lib.rs
@@ -485,6 +485,7 @@ impl GlitchFilter for SetZero {
 
 #[derive(Debug, Clone, Copy, ValueEnum, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[derive(Debug, Clone, Copy)]
 pub enum SortCriterion {
     Brightness,
     Hue,
@@ -550,6 +551,7 @@ impl PixelSort {
 
 #[derive(Debug, Clone, Copy, ValueEnum, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[derive(Debug, Clone, Copy)]
 pub enum BitOp {
     And,
     Or,
@@ -584,6 +586,7 @@ impl GlitchFilter for Bitwise {
 
 #[derive(Debug, Clone, Copy, ValueEnum, Deserialize)]
 #[serde(rename_all = "lowercase")]
+#[derive(Debug, Clone, Copy)]
 pub enum SwapTarget {
     Rg,
     Gb,

--- a/crates/glitch-context/src/lib.rs
+++ b/crates/glitch-context/src/lib.rs
@@ -485,7 +485,6 @@ impl GlitchFilter for SetZero {
 
 #[derive(Debug, Clone, Copy, ValueEnum, Deserialize)]
 #[serde(rename_all = "lowercase")]
-#[derive(Debug, Clone, Copy)]
 pub enum SortCriterion {
     Brightness,
     Hue,
@@ -551,7 +550,6 @@ impl PixelSort {
 
 #[derive(Debug, Clone, Copy, ValueEnum, Deserialize)]
 #[serde(rename_all = "lowercase")]
-#[derive(Debug, Clone, Copy)]
 pub enum BitOp {
     And,
     Or,
@@ -586,7 +584,6 @@ impl GlitchFilter for Bitwise {
 
 #[derive(Debug, Clone, Copy, ValueEnum, Deserialize)]
 #[serde(rename_all = "lowercase")]
-#[derive(Debug, Clone, Copy)]
 pub enum SwapTarget {
     Rg,
     Gb,

--- a/crates/png-glitch/src/presets.rs
+++ b/crates/png-glitch/src/presets.rs
@@ -65,21 +65,16 @@ pub struct Brighten {
 impl GlitchPreset for Brighten {
     fn apply_to_line(&self, line: &mut ScanLine) {
         let strength = self.strength;
+        let max_val = ((1u32 << line.bit_depth() as u32).saturating_sub(1)) as u16;
         line.process_pixels(|_, pixel| {
+            let brighten = |v: u16| v.saturating_add(strength).min(max_val);
             match pixel {
-                Pixel::Gray(v) => Pixel::Gray(v.saturating_add(strength)),
-                Pixel::GrayAlpha(v, a) => Pixel::GrayAlpha(v.saturating_add(strength), a),
-                Pixel::RGB(r, g, b) => Pixel::RGB(
-                    r.saturating_add(strength),
-                    g.saturating_add(strength),
-                    b.saturating_add(strength),
-                ),
-                Pixel::RGBA(r, g, b, a) => Pixel::RGBA(
-                    r.saturating_add(strength),
-                    g.saturating_add(strength),
-                    b.saturating_add(strength),
-                    a,
-                ),
+                Pixel::Gray(v) => Pixel::Gray(brighten(v)),
+                Pixel::GrayAlpha(v, a) => Pixel::GrayAlpha(brighten(v), a),
+                Pixel::RGB(r, g, b) => Pixel::RGB(brighten(r), brighten(g), brighten(b)),
+                Pixel::RGBA(r, g, b, a) => {
+                    Pixel::RGBA(brighten(r), brighten(g), brighten(b), a)
+                }
                 Pixel::Indexed(v) => Pixel::Indexed(v.saturating_add(strength as u8)),
             }
         });
@@ -113,7 +108,6 @@ mod tests {
         let mut data = vec![0, 100, 200, 250];
         let mut line = ScanLine::new(&mut data, ColorType::TrueColor, 8, 1);
         Brighten { strength: 10 }.apply_to_line(&mut line);
-        // 250 + 10 = 260. 260 as u8 is 4.
-        assert_eq!(line.get_pixel(0).unwrap(), Pixel::RGB(110, 210, 4));
+        assert_eq!(line.get_pixel(0).unwrap(), Pixel::RGB(110, 210, 255));
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -5,126 +5,10 @@ use serde::Deserialize;
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Cli {
-    #[arg(short, default_value = "glitched.png")]
+    #[arg(short, long = "output", default_value = "glitched.png")]
     pub output_file: String,
 
     pub png_file: String,
-
-    /// Magnitude for Change Filter Type filter
-    #[arg(long)]
-    pub change_filter_type: Option<f64>,
-
-    /// Magnitude for Replace filter
-    #[arg(long)]
-    pub replace: Option<f64>,
-
-    /// Magnitude for Transpose filter
-    #[arg(long)]
-    pub transpose: Option<f64>,
-
-    /// Magnitude for Set Zero filter
-    #[arg(long)]
-    pub set_zero: Option<f64>,
-
-    /// Number of times for Random Copy filter
-    #[arg(long)]
-    pub random_copy: Option<u32>,
-
-    /// Substitute byte at index with value (index:value)
-    #[arg(long)]
-    pub substitute: Option<String>,
-
-    /// Pixel Sort magnitude
-    #[arg(long)]
-    pub pixel_sort: Option<f64>,
-
-    /// Pixel Sort criterion (brightness, hue)
-    #[arg(long, value_enum, default_value_t = SortCriterion::Brightness)]
-    pub pixel_sort_criterion: SortCriterion,
-
-    /// Bitwise operation magnitude
-    #[arg(long)]
-    pub bitwise: Option<f64>,
-
-    /// Bitwise operation (and, or, xor)
-    #[arg(long, value_enum, default_value_t = BitOp::Xor)]
-    pub bitwise_op: BitOp,
-
-    /// Bitwise operation value
-    #[arg(long, default_value_t = 0)]
-    pub bitwise_value: u8,
-
-    /// Channel Swap magnitude
-    #[arg(long)]
-    pub channel_swap: Option<f64>,
-
-    /// Channel Swap target (rg, gb, br)
-    #[arg(long, value_enum, default_value_t = SwapTarget::Rg)]
-    pub channel_swap_target: SwapTarget,
-
-    /// Horizontal Shift magnitude
-    #[arg(long)]
-    pub horizontal_shift: Option<f64>,
-
-    /// Block Scramble magnitude
-    #[arg(long)]
-    pub block_scramble: Option<f64>,
-
-    /// Block Scramble block size
-    #[arg(long, default_value_t = 16)]
-    pub block_scramble_size: u32,
-
-    /// Color Distortion magnitude
-    #[arg(long)]
-    pub color_distortion: Option<f64>,
-
-    /// Color Distortion strength
-    #[arg(long, default_value_t = 20)]
-    pub color_distortion_strength: i16,
-
-    /// Color Space Glitch magnitude (HSL)
-    #[arg(long)]
-    pub color_space_glitch: Option<f64>,
-
-    /// Hue shift (0.0 - 360.0)
-    #[arg(long, default_value_t = 0.0)]
-    pub hue_shift: f64,
-
-    /// Saturation multiplier
-    #[arg(long, default_value_t = 1.0)]
-    pub saturation_mult: f64,
-
-    /// Lightness multiplier
-    #[arg(long, default_value_t = 1.0)]
-    pub lightness_mult: f64,
-
-    /// Chromatic Aberration magnitude
-    #[arg(long)]
-    pub chromatic_aberration: Option<f64>,
-
-    /// Red channel offset
-    #[arg(long, default_value_t = 2)]
-    pub r_offset: i32,
-
-    /// Green channel offset
-    #[arg(long, default_value_t = 0)]
-    pub g_offset: i32,
-
-    /// Blue channel offset
-    #[arg(long, default_value_t = -2)]
-    pub b_offset: i32,
-
-    /// Invert colors
-    #[arg(long)]
-    pub invert: bool,
-
-    /// Brighten image (strength)
-    #[arg(long)]
-    pub brighten: Option<u16>,
-
-    /// Shift channels (r,g,b)
-    #[arg(long, value_delimiter = ',')]
-    pub shift_channels: Option<Vec<i16>>,
 
     /// Random seed
     #[arg(long)]
@@ -138,41 +22,156 @@ pub struct Cli {
     #[arg(long)]
     pub config: Option<String>,
 
-    /// Remove filter from all scan lines
-    #[arg(long)]
-    pub remove_filter: bool,
+    /// Magnitude for Change Filter Type filter
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub change_filter_type: Option<f64>,
 
-    /// Change filter type of all scan lines to Sub
-    #[arg(long)]
-    pub sub: bool,
+    /// Magnitude for Replace filter
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub replace: Option<f64>,
 
-    /// Change filter type of all scan lines to Up
-    #[arg(long)]
-    pub up: bool,
+    /// Magnitude for Transpose filter
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub transpose: Option<f64>,
 
-    /// Change filter type of all scan lines to Average
-    #[arg(long)]
-    pub average: bool,
+    /// Magnitude for Set Zero filter
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub set_zero: Option<f64>,
 
-    /// Change filter type of all scan lines to Paeth
-    #[arg(long)]
-    pub paeth: bool,
+    /// Number of times for Random Copy filter
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub random_copy: Option<u32>,
 
-    /// Apply a filter before other glitch filters
-    #[arg(long, value_enum)]
+    /// Substitute byte at index with value (index:value)
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub substitute: Option<String>,
+
+    /// Pixel Sort magnitude
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub pixel_sort: Option<f64>,
+
+    /// Pixel Sort criterion (brightness, hue)
+    #[arg(long, value_enum, default_value_t = SortCriterion::Brightness, help_heading = "Glitch Filters")]
+    pub pixel_sort_criterion: SortCriterion,
+
+    /// Bitwise operation magnitude
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub bitwise: Option<f64>,
+
+    /// Bitwise operation (and, or, xor)
+    #[arg(long, value_enum, default_value_t = BitOp::Xor, help_heading = "Glitch Filters")]
+    pub bitwise_op: BitOp,
+
+    /// Bitwise operation value
+    #[arg(long, default_value_t = 0, help_heading = "Glitch Filters")]
+    pub bitwise_value: u8,
+
+    /// Channel Swap magnitude
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub channel_swap: Option<f64>,
+
+    /// Channel Swap target (rg, gb, br)
+    #[arg(long, value_enum, default_value_t = SwapTarget::Rg, help_heading = "Glitch Filters")]
+    pub channel_swap_target: SwapTarget,
+
+    /// Horizontal Shift magnitude
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub horizontal_shift: Option<f64>,
+
+    /// Block Scramble magnitude
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub block_scramble: Option<f64>,
+
+    /// Block Scramble block size
+    #[arg(long, default_value_t = 16, help_heading = "Glitch Filters")]
+    pub block_scramble_size: u32,
+
+    /// Color Distortion magnitude
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub color_distortion: Option<f64>,
+
+    /// Color Distortion strength
+    #[arg(long, default_value_t = 20, help_heading = "Glitch Filters")]
+    pub color_distortion_strength: i16,
+
+    /// Color Space Glitch magnitude (HSL)
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub color_space_glitch: Option<f64>,
+
+    /// Hue shift (0.0 - 360.0)
+    #[arg(long, default_value_t = 0.0, help_heading = "Glitch Filters")]
+    pub hue_shift: f64,
+
+    /// Saturation multiplier
+    #[arg(long, default_value_t = 1.0, help_heading = "Glitch Filters")]
+    pub saturation_mult: f64,
+
+    /// Lightness multiplier
+    #[arg(long, default_value_t = 1.0, help_heading = "Glitch Filters")]
+    pub lightness_mult: f64,
+
+    /// Chromatic Aberration magnitude
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub chromatic_aberration: Option<f64>,
+
+    /// Red channel offset
+    #[arg(long, default_value_t = 2, help_heading = "Glitch Filters")]
+    pub r_offset: i32,
+
+    /// Green channel offset
+    #[arg(long, default_value_t = 0, help_heading = "Glitch Filters")]
+    pub g_offset: i32,
+
+    /// Blue channel offset
+    #[arg(long, default_value_t = -2, help_heading = "Glitch Filters")]
+    pub b_offset: i32,
+
+    /// Invert colors
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub invert: bool,
+
+    /// Brighten image (strength)
+    #[arg(long, help_heading = "Glitch Filters")]
+    pub brighten: Option<u16>,
+
+    /// Shift channels (r,g,b)
+    #[arg(long, value_delimiter = ',', help_heading = "Glitch Filters")]
+    pub shift_channels: Option<Vec<i16>>,
+
+    /// Change the PNG filter type of all scan lines before applying glitch filters
+    #[arg(long, value_enum, help_heading = "Pre-processing (applied before glitch filters)")]
     pub pre_process: Option<PreProcess>,
 
-    // WebP 専用オプション
+    /// Set all scan lines to filter type None
+    #[arg(long, help_heading = "Filter Type Override (force all scan lines to a fixed filter type)")]
+    pub remove_filter: bool,
+
+    /// Set all scan lines to filter type Sub
+    #[arg(long, help_heading = "Filter Type Override (force all scan lines to a fixed filter type)")]
+    pub sub: bool,
+
+    /// Set all scan lines to filter type Up
+    #[arg(long, help_heading = "Filter Type Override (force all scan lines to a fixed filter type)")]
+    pub up: bool,
+
+    /// Set all scan lines to filter type Average
+    #[arg(long, help_heading = "Filter Type Override (force all scan lines to a fixed filter type)")]
+    pub average: bool,
+
+    /// Set all scan lines to filter type Paeth
+    #[arg(long, help_heading = "Filter Type Override (force all scan lines to a fixed filter type)")]
+    pub paeth: bool,
+
     /// Macroblock glitch magnitude (WebP only)
-    #[arg(long)]
+    #[arg(long, help_heading = "WebP Filters")]
     pub macroblock_glitch: Option<f64>,
 
     /// Alpha channel glitch strategy: invert, randomize, zero, one (WebP only)
-    #[arg(long)]
+    #[arg(long, help_heading = "WebP Filters")]
     pub alpha_glitch: Option<String>,
 
     /// Re-encode quality for lossy artifact effect, 0.0-100.0 (WebP only)
-    #[arg(long)]
+    #[arg(long, help_heading = "WebP Filters")]
     pub lossy_quality: Option<f32>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,9 +87,7 @@ fn batch_process(args: &Cli, output_dir: &str) -> anyhow::Result<()> {
     );
 
     png_files.par_iter().for_each(|path| {
-        let file_name = path
-            .file_name()
-            .unwrap_or_default();
+        let file_name = path.file_name().unwrap_or_default();
         let dest_path = output_path.join(file_name);
 
         pb.set_message(format!("Processing {:?}", file_name));
@@ -129,22 +127,19 @@ fn batch_process(args: &Cli, output_dir: &str) -> anyhow::Result<()> {
 }
 
 fn apply_filters(args: &Cli, context: &mut GlitchContext) -> anyhow::Result<()> {
-    // Apply pre-process filter first
     if let Some(pre_process) = args.pre_process {
         context.pre_process(pre_process);
     }
 
-    // Apply config file filters if present
     if let Some(config_path) = &args.config {
         let file = File::open(config_path).context("Failed to open config file")?;
         let config: ConfigFile =
-            serde_yaml::from_reader(file).context("Failed to parse config file")?;
+            serde_yml::from_reader(file).context("Failed to parse config file")?;
         for filter in config.filters {
             context.add_from_config(filter);
         }
     }
 
-    // Apply CLI flags
     if let Some(magnitude) = args.change_filter_type {
         context.add_filter(ChangeFilterType { magnitude });
     }
@@ -256,7 +251,7 @@ fn apply_webp_filters(args: &Cli, context: &mut WebpGlitchContext) -> anyhow::Re
     if let Some(config_path) = &args.config {
         let file = File::open(config_path).context("Failed to open config file")?;
         let config: ConfigFile =
-            serde_yaml::from_reader(file).context("Failed to parse config file")?;
+            serde_yml::from_reader(file).context("Failed to parse config file")?;
         for filter_cfg in config.filters {
             match filter_cfg {
                 FilterConfig::Invert => context.add_filter(WebpInvert),


### PR DESCRIPTION
## Summary

- **`Brighten` バグ修正**: `u16::saturating_add` がビット深度の最大値ではなく `u16::MAX` で飽和していた問題を修正。8-bit 画像では 255 で正しく飽和するようになった
- **`serde_yaml` を `serde_yml` に移行**: `serde_yaml 0.9` が deprecated のため、メンテナンスされている後継パッケージに置き換え
- **`--output` long オプション追加**: 出力ファイル指定が `-o` のみだったところに `--output` を追加
- **デッドコード削除**: 未使用の `src/wasm_runner.rs` を削除
- **`--help` のセクション整理**: `Glitch Filters` / `Pre-processing` / `Filter Type Override` の3セクションに分け、各オプションの用途の違いを明確化
- **README 更新**: 新フィルター・変更点をすべて反映

## Test plan

- [ ] `cargo test -p png-glitch` — Brighten の飽和動作を含む全42テストが通過することを確認
- [ ] `cargo build` — 警告なしでビルドが通ることを確認
- [ ] `png-glitch --help` — 3セクションに分かれて表示されることを確認
- [ ] `png-glitch input.png --output out.png` — `--output` オプションが動作することを確認
- [ ] `png-glitch input.png --brighten 30` — 明るい部分が 255 でクリップされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)